### PR TITLE
Improve the data import logic, support customized compliant json/plainText imports

### DIFF
--- a/Keyden/Views/SettingsView.swift
+++ b/Keyden/Views/SettingsView.swift
@@ -1067,17 +1067,75 @@ struct DataTabContent: View {
         }
     }
     
+    /// Simple import format for external JSON files (e.g., converted_keyden.json)
+    /// Supports flexible import with auto-generated missing fields
+    private struct SimpleImportToken: Codable {
+        let account: String?
+        let label: String?
+        let isPinned: Bool?
+        let issuer: String?
+        let sortOrder: Int?
+        let secret: String
+        // Additional optional fields
+        let algorithm: String?
+        let digits: Int?
+        let period: Int?
+        let id: String?
+        let updatedAt: Double?
+        
+        /// Convert algorithm string to TOTPAlgorithm enum
+        private func parseAlgorithm() -> TOTPAlgorithm {
+            switch algorithm?.uppercased() {
+            case "SHA256": return .sha256
+            case "SHA512": return .sha512
+            default: return .sha1
+            }
+        }
+        
+        /// Convert to Token with auto-generated missing fields
+        func toToken(sortIndex: Int) -> Token {
+            Token(
+                id: UUID(),  // Auto-generate new UUID
+                issuer: issuer ?? "",
+                account: account ?? "",
+                label: label ?? "",
+                secret: secret,
+                digits: digits ?? 6,
+                period: period ?? 30,
+                algorithm: parseAlgorithm(),
+                sortOrder: sortOrder ?? sortIndex,  // Use index if not provided
+                isPinned: isPinned ?? false,
+                updatedAt: Date()  // Auto-generate current timestamp
+            )
+        }
+    }
+    
     private func performImport() {
         guard let url = importURL else { return }
         
         do {
             let data = try Data(contentsOf: url)
-            let importedVault = try JSONDecoder().decode(Vault.self, from: data)
+            var tokens: [Token] = []
+            
+            // Try to decode as native Vault format first
+            if let importedVault = try? JSONDecoder().decode(Vault.self, from: data) {
+                tokens = importedVault.tokens
+            }
+            // Try to decode as simple JSON array format (e.g., converted_keyden.json)
+            else if let simpleTokens = try? JSONDecoder().decode([SimpleImportToken].self, from: data) {
+                tokens = simpleTokens.enumerated().map { index, item in
+                    item.toToken(sortIndex: index)
+                }
+            }
+            // If both fail, report error
+            else {
+                throw NSError(domain: "ImportError", code: -1, userInfo: [NSLocalizedDescriptionKey: "Unrecognized file format"])
+            }
             
             var addedCount = 0
             var skippedCount = 0
             
-            for token in importedVault.tokens {
+            for token in tokens {
                 // Check for duplicate by secret
                 let isDuplicate = vaultService.vault.tokens.contains { $0.secret == token.secret }
                 if isDuplicate {


### PR DESCRIPTION
提交导入的逻辑完善，在保留原有导入逻辑的情况下，支持自定义的导入逻辑，原因是现在的2FA应用是在是太多了，无法完全适配，通过导出其他2FA的已有内容，构建json，导入keyden，实现一次性的操作

# feat1: 
拟定的支持格式如下：
```json
[
	{
		"label": "test111",
		"account": "test1111@163.com",
		"algorithm": "SHA1",
		"digits": 6,
		"issuer": "NeteaseMail",
		"period": 30,
		"secret": "123456789"
	}
]
```
# feat2: 
支持纯文本格式的导入，格式如下：

```plaintext
otpauth://totp/test111@163.com?algorithm=SHA1&digits=6&issuer=NeteaseMail&period=30&secret=11111111111111
otpauth://totp/test222@163.com?algorithm=SHA1&digits=6&issuer=NeteaseMail&period=30&secret=22222222222222
otpauth://totp/test333@163.com?algorithm=SHA1&digits=6&issuer=NeteaseMail&period=30&secret=33333333333333
otpauth://totp/test444@163.com?algorithm=SHA1&digits=6&issuer=NeteaseMail&period=30&secret=44444444444444
otpauth://totp/test555@163.com?algorithm=SHA1&digits=6&issuer=NeteaseMail&period=30&secret=55555555555555
```
