### PR TITLE
feat: add CI/CD release automation with Homebrew tap submodule integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,326 @@
+# =============================================================================
+# release.yml — Keyden 自动发布工作流
+# =============================================================================
+# 当推送 vX.Y.Z 格式的 tag 时自动触发：
+#   1. 验证 tag 格式 & 版本一致性 (tag ↔ project.pbxproj)
+#   2. 构建 DMG (arm64, x86_64, universal)
+#   3. 创建 GitHub Release 并上传 DMG
+#   4. 更新 homebrew-tap submodule 中的 Cask formula
+#
+# 所需 Secrets:
+#   - HOMEBREW_TAP_TOKEN: 拥有 homebrew-tap 仓库 push 权限的 PAT
+# =============================================================================
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+
+env:
+  PROJECT_NAME: Keyden
+
+jobs:
+  # ===========================================================================
+  # Job 1: 验证版本一致性
+  # ===========================================================================
+  validate:
+    name: Validate Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.parse.outputs.version }}
+      tag: ${{ steps.parse.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Parse and validate tag
+        id: parse
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "🏷️  Tag: ${TAG}"
+
+          # Validate tag format: must be vX.Y.Z (no extra dots)
+          if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "❌ Invalid tag format: '${TAG}'"
+            echo "   Expected: vX.Y.Z (e.g. v1.0.10)"
+            echo "   Common mistake: v.1.0.10 (extra dot after v)"
+            exit 1
+          fi
+
+          VERSION="${TAG#v}"
+          echo "📦 Version: ${VERSION}"
+
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+
+      - name: Verify version matches project.pbxproj
+        run: |
+          VERSION="${{ steps.parse.outputs.version }}"
+
+          # Extract MARKETING_VERSION from pbxproj
+          PBXPROJ_VERSION=$(grep -m1 'MARKETING_VERSION' \
+            ${{ env.PROJECT_NAME }}.xcodeproj/project.pbxproj \
+            | sed 's/.*= *\([^;]*\);.*/\1/' | tr -d ' ')
+
+          echo "🔍 Comparing versions..."
+          echo "   Tag version:     ${VERSION}"
+          echo "   pbxproj version: ${PBXPROJ_VERSION}"
+
+          if [ "$VERSION" != "$PBXPROJ_VERSION" ]; then
+            echo ""
+            echo "❌ Version mismatch!"
+            echo "   Tag says '${VERSION}' but project.pbxproj says '${PBXPROJ_VERSION}'"
+            echo "   Please update MARKETING_VERSION in project.pbxproj before tagging."
+            exit 1
+          fi
+
+          echo "✅ Versions match: ${VERSION}"
+
+  # ===========================================================================
+  # Job 2: 构建 DMG
+  # ===========================================================================
+  build:
+    name: Build DMGs
+    needs: validate
+    runs-on: macos-latest
+    outputs:
+      sha256_arm64: ${{ steps.sha.outputs.arm64 }}
+      sha256_x86_64: ${{ steps.sha.outputs.x86_64 }}
+      sha256_universal: ${{ steps.sha.outputs.universal }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode version
+        run: |
+          # Use the latest stable Xcode on the runner
+          sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+          xcodebuild -version
+
+      - name: Build all DMGs
+        run: |
+          make dmg
+          echo ""
+          echo "📦 Built DMGs:"
+          ls -lh dist/*.dmg
+
+      - name: Compute SHA256
+        id: sha
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+
+          SHA_ARM64=$(shasum -a 256 "dist/${{ env.PROJECT_NAME }}-${VERSION}-arm64.dmg" | awk '{print $1}')
+          SHA_X86=$(shasum -a 256 "dist/${{ env.PROJECT_NAME }}-${VERSION}-x86_64.dmg" | awk '{print $1}')
+          SHA_UNI=$(shasum -a 256 "dist/${{ env.PROJECT_NAME }}-${VERSION}-universal.dmg" | awk '{print $1}')
+
+          echo "arm64=${SHA_ARM64}" >> $GITHUB_OUTPUT
+          echo "x86_64=${SHA_X86}" >> $GITHUB_OUTPUT
+          echo "universal=${SHA_UNI}" >> $GITHUB_OUTPUT
+
+          echo "🔑 SHA256 checksums:"
+          echo "   arm64:     ${SHA_ARM64}"
+          echo "   x86_64:    ${SHA_X86}"
+          echo "   universal: ${SHA_UNI}"
+
+      - name: Upload DMG artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dmg-files
+          path: dist/*.dmg
+          retention-days: 5
+
+  # ===========================================================================
+  # Job 3: 创建 GitHub Release
+  # ===========================================================================
+  release:
+    name: Create Release
+    needs: [validate, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download DMG artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dmg-files
+          path: dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.validate.outputs.tag }}
+          name: "${{ env.PROJECT_NAME }} ${{ needs.validate.outputs.tag }}"
+          draft: false
+          prerelease: false
+          files: |
+            dist/*.dmg
+          body: |
+            ## ${{ env.PROJECT_NAME }} ${{ needs.validate.outputs.tag }}
+
+            ### Downloads
+
+            | Platform | File | SHA256 |
+            |----------|------|--------|
+            | Apple Silicon (arm64) | `${{ env.PROJECT_NAME }}-${{ needs.validate.outputs.version }}-arm64.dmg` | `${{ needs.build.outputs.sha256_arm64 }}` |
+            | Intel (x86_64) | `${{ env.PROJECT_NAME }}-${{ needs.validate.outputs.version }}-x86_64.dmg` | `${{ needs.build.outputs.sha256_x86_64 }}` |
+            | Universal | `${{ env.PROJECT_NAME }}-${{ needs.validate.outputs.version }}-universal.dmg` | `${{ needs.build.outputs.sha256_universal }}` |
+
+            ### Install via Homebrew
+
+            ```bash
+            brew install --cask tasselx/tap/keyden
+            ```
+
+  # ===========================================================================
+  # Job 4: 更新 Homebrew Tap (Submodule)
+  # ===========================================================================
+  update-homebrew:
+    name: Update Homebrew Tap
+    needs: [validate, build, release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout homebrew-tap
+        uses: actions/checkout@v4
+        with:
+          repository: tasselx/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update Cask formula
+        working-directory: homebrew-tap
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          SHA256_ARM64="${{ needs.build.outputs.sha256_arm64 }}"
+          SHA256_X86="${{ needs.build.outputs.sha256_x86_64 }}"
+          CASK_FILE="Casks/keyden.rb"
+
+          echo "📝 Updating Cask to v${VERSION}..."
+
+          cat > "${CASK_FILE}" << EOF
+          cask "keyden" do
+            version "${VERSION}"
+            arch arm: "arm64", intel: "x86_64"
+
+            sha256 arm:   "${SHA256_ARM64}",
+                   intel: "${SHA256_X86}"
+
+            url "https://github.com/tasselx/Keyden/releases/download/v#{version}/Keyden-#{version}-#{arch}.dmg",
+                verified: "github.com/tasselx/Keyden/"
+            name "Keyden"
+            desc "macOS menu bar TOTP authenticator"
+            homepage "https://tasselx.github.io/Keyden/"
+
+            depends_on macos: :monterey
+
+            app "Keyden.app"
+          end
+          EOF
+
+          # Remove heredoc leading whitespace
+          sed -i 's/^          //' "${CASK_FILE}"
+
+          echo "📄 Updated Cask:"
+          cat "${CASK_FILE}"
+
+      - name: Validate Cask syntax
+        working-directory: homebrew-tap
+        run: ruby -c Casks/keyden.rb
+
+      - name: Verify download URL
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          URL="https://github.com/tasselx/Keyden/releases/download/v${VERSION}/Keyden-${VERSION}-arm64.dmg"
+
+          echo "🔍 Verifying: ${URL}"
+          HTTP_CODE=$(curl -sI -o /dev/null -w "%{http_code}" -L "$URL")
+
+          if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "302" ]; then
+            echo "❌ Download URL not reachable (HTTP ${HTTP_CODE})"
+            exit 1
+          fi
+          echo "✅ Download URL reachable (HTTP ${HTTP_CODE})"
+
+      - name: Commit and push to homebrew-tap
+        working-directory: homebrew-tap
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add Casks/keyden.rb
+          if git diff --cached --quiet; then
+            echo "ℹ️  Cask already up to date"
+            exit 0
+          fi
+
+          git commit -m "Update keyden to ${VERSION}"
+          git push
+
+          echo "✅ homebrew-tap updated to v${VERSION}"
+
+      # Update submodule reference in main repo
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          submodules: true
+          path: main-repo
+
+      - name: Update submodule reference
+        working-directory: main-repo
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+
+          # Update submodule to latest
+          git submodule update --remote homebrew-tap || {
+            echo "ℹ️  No homebrew-tap submodule found, skipping submodule update"
+            exit 0
+          }
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add homebrew-tap
+          if git diff --cached --quiet; then
+            echo "ℹ️  Submodule reference already up to date"
+            exit 0
+          fi
+
+          git commit -m "chore: update homebrew-tap submodule to v${VERSION}"
+          git push
+
+          echo "✅ Submodule reference updated"
+
+  # ===========================================================================
+  # Job 5: Summary
+  # ===========================================================================
+  summary:
+    name: Release Summary
+    needs: [validate, build, release, update-homebrew]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate summary
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          TAG="${{ needs.validate.outputs.tag }}"
+
+          echo "## 🎉 Release ${TAG} Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Step | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Version Validation | ${{ needs.validate.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Build DMGs | ${{ needs.build.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| GitHub Release | ${{ needs.release.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Homebrew Tap Update | ${{ needs.update-homebrew.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Checksums" >> $GITHUB_STEP_SUMMARY
+          echo "| Arch | SHA256 |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| arm64 | \`${{ needs.build.outputs.sha256_arm64 }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| x86_64 | \`${{ needs.build.outputs.sha256_x86_64 }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| universal | \`${{ needs.build.outputs.sha256_universal }}\` |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,208 @@
+# =============================================================================
+# version-check.yml — 版本一致性验证
+# =============================================================================
+# 在每次 push/PR 时自动检查：
+#   1. project.pbxproj 中的 MARKETING_VERSION 格式是否合法 (semver)
+#   2. homebrew-tap submodule 中 Cask 版本是否与项目版本一致
+#   3. Cask 语法是否正确
+#   4. depends_on 格式是否使用了已废弃的字符串比较
+# =============================================================================
+
+name: Version Check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '*.xcodeproj/**'
+      - 'homebrew-tap/**'
+  pull_request:
+    paths:
+      - '*.xcodeproj/**'
+      - 'homebrew-tap/**'
+
+  # 允许手动触发
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  PROJECT_NAME: Keyden
+
+jobs:
+  version-check:
+    name: Version Consistency Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      # -----------------------------------------------------------------------
+      # Check 1: Validate MARKETING_VERSION format
+      # -----------------------------------------------------------------------
+      - name: Check pbxproj version format
+        id: pbxproj
+        run: |
+          PBXPROJ="${{ env.PROJECT_NAME }}.xcodeproj/project.pbxproj"
+
+          if [ ! -f "$PBXPROJ" ]; then
+            echo "❌ project.pbxproj not found at: ${PBXPROJ}"
+            exit 1
+          fi
+
+          VERSION=$(grep -m1 'MARKETING_VERSION' "$PBXPROJ" \
+            | sed 's/.*= *\([^;]*\);.*/\1/' | tr -d ' ')
+
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "📦 MARKETING_VERSION: ${VERSION}"
+
+          if [ -z "$VERSION" ]; then
+            echo "❌ MARKETING_VERSION not found in project.pbxproj"
+            exit 1
+          fi
+
+          # Validate semver format
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "❌ Invalid version format: '${VERSION}'"
+            echo "   Expected: X.Y.Z (e.g. 1.0.10)"
+            exit 1
+          fi
+
+          echo "✅ Version format valid: ${VERSION}"
+
+      # -----------------------------------------------------------------------
+      # Check 2: Validate Cask version matches (if submodule exists)
+      # -----------------------------------------------------------------------
+      - name: Check Cask version consistency
+        run: |
+          CASK_FILE="homebrew-tap/Casks/keyden.rb"
+          PBXPROJ_VERSION="${{ steps.pbxproj.outputs.version }}"
+
+          if [ ! -f "$CASK_FILE" ]; then
+            echo "ℹ️  homebrew-tap submodule not found, skipping Cask check"
+            echo "   (Expected: ${CASK_FILE})"
+            exit 0
+          fi
+
+          # Extract version from Cask
+          CASK_VERSION=$(grep -oP 'version\s+"[^"]+"' "$CASK_FILE" \
+            | grep -oP '"[^"]+"' | tr -d '"')
+
+          echo "🔍 Comparing versions..."
+          echo "   pbxproj version: ${PBXPROJ_VERSION}"
+          echo "   Cask version:    ${CASK_VERSION}"
+
+          if [ "$PBXPROJ_VERSION" != "$CASK_VERSION" ]; then
+            echo ""
+            echo "⚠️  Version mismatch detected!"
+            echo "   This is expected during development."
+            echo "   The Cask will be auto-updated when you create a release tag."
+            echo ""
+            echo "   If you just released v${PBXPROJ_VERSION}, the Cask should be updated."
+          else
+            echo "✅ Versions are in sync: ${PBXPROJ_VERSION}"
+          fi
+
+      # -----------------------------------------------------------------------
+      # Check 3: Validate Cask syntax
+      # -----------------------------------------------------------------------
+      - name: Check Cask syntax
+        run: |
+          CASK_FILE="homebrew-tap/Casks/keyden.rb"
+
+          if [ ! -f "$CASK_FILE" ]; then
+            echo "ℹ️  Cask file not found, skipping syntax check"
+            exit 0
+          fi
+
+          echo "🔍 Checking Ruby syntax..."
+          ruby -c "$CASK_FILE"
+          echo "✅ Cask syntax OK"
+
+      # -----------------------------------------------------------------------
+      # Check 4: Check for deprecated depends_on format
+      # -----------------------------------------------------------------------
+      - name: Check for deprecated Homebrew patterns
+        run: |
+          CASK_FILE="homebrew-tap/Casks/keyden.rb"
+
+          if [ ! -f "$CASK_FILE" ]; then
+            echo "ℹ️  Cask file not found, skipping deprecation check"
+            exit 0
+          fi
+
+          echo "🔍 Checking for deprecated patterns..."
+
+          FOUND_ISSUES=0
+
+          # Check for deprecated string comparison in depends_on macos
+          if grep -qE 'depends_on\s+macos:\s+"' "$CASK_FILE"; then
+            echo "❌ Deprecated: depends_on macos uses string comparison format"
+            echo "   Found:    $(grep 'depends_on.*macos' "$CASK_FILE" | tr -d ' ')"
+            echo "   Expected: depends_on macos: :monterey  (symbol format)"
+            echo ""
+            echo "   String comparison format is deprecated by Homebrew."
+            echo "   Use symbol format instead: depends_on macos: :monterey"
+            echo "   (Symbol format already implies '>=')"
+            FOUND_ISSUES=1
+          fi
+
+          # Check for invalid tag format in URL (v.X.Y.Z)
+          if grep -qE 'v\.\#\{version\}' "$CASK_FILE"; then
+            echo "❌ Suspicious URL pattern: 'v.#{version}' (extra dot after v)"
+            echo "   Expected: 'v#{version}'"
+            FOUND_ISSUES=1
+          fi
+
+          if [ "$FOUND_ISSUES" = "1" ]; then
+            echo ""
+            echo "❌ Deprecated patterns found! Please fix them."
+            exit 1
+          fi
+
+          echo "✅ No deprecated patterns found"
+
+      # -----------------------------------------------------------------------
+      # Check 5: Validate URL template
+      # -----------------------------------------------------------------------
+      - name: Validate URL template
+        run: |
+          CASK_FILE="homebrew-tap/Casks/keyden.rb"
+
+          if [ ! -f "$CASK_FILE" ]; then
+            echo "ℹ️  Cask file not found, skipping URL check"
+            exit 0
+          fi
+
+          echo "🔍 Checking URL template..."
+
+          # Verify URL uses v#{version} (not v.#{version} or other variants)
+          if grep -q 'download/v#{version}/' "$CASK_FILE"; then
+            echo "✅ URL template uses correct format: v#{version}"
+          elif grep -q 'download/' "$CASK_FILE"; then
+            echo "⚠️  URL template may have non-standard version format"
+            grep 'download/' "$CASK_FILE"
+          fi
+
+          # Verify arch interpolation
+          if grep -q '#{arch}.dmg' "$CASK_FILE"; then
+            echo "✅ URL template uses arch interpolation"
+          fi
+
+      # -----------------------------------------------------------------------
+      # Summary
+      # -----------------------------------------------------------------------
+      - name: Summary
+        if: always()
+        run: |
+          VERSION="${{ steps.pbxproj.outputs.version }}"
+
+          echo "## 🔍 Version Check Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Item | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| MARKETING_VERSION | \`${VERSION}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Format | ✅ Valid semver |" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,5 @@ dist/
 *.xcarchive
 *.xcuserstate
 **/xcuserdata/
+
+.agents/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "homebrew-tap"]
+	path = homebrew-tap
+	url = https://github.com/tasselx/homebrew-tap.git


### PR DESCRIPTION
## 概述

本 PR 为 Keyden 项目引入完整的 CI/CD 自动化发布流程，通过将 `homebrew-tap` 作为 Git Submodule 集成，实现版本发布与 Homebrew Cask 更新的原子性联动，从根源上消除手动发布时的版本号错误问题。

## 背景 & 动机

v1.0.10 发布时，Release tag 被误写为 `v.1.0.10`（`v` 和 `1` 之间多了一个点），而 Homebrew Cask 的 URL 模板 `v#{version}` 展开为 `v1.0.10`，导致下载地址不匹配，用户 `brew install` 遭遇 HTTP 404。

| 版本 | Tag 格式 | 状态 |
|------|---------|------|
| v1.0.9 | `v1.0.9` | ✅ 正确 |
| **v1.0.10** | `v.1.0.10` | ❌ 多了一个点 |

## 变更内容

### 1. 添加 `homebrew-tap` 作为 Git Submodule

```ini
[submodule "homebrew-tap"]
    path = homebrew-tap
    url = https://github.com/tasselx/homebrew-tap.git
```

- 在 Keyden 仓库中维护对 homebrew-tap 的版本引用
- 发布工作流可以直接操作 submodule 中的 Cask 文件
- 版本变更历史在 Keyden 仓库中清晰可追溯

### 2. 自动发布工作流 `release.yml`

**触发条件**：推送 `vX.Y.Z` 格式的 Git tag

**完整流水线（5 个 Job）**：
```
Tag Push (vX.Y.Z)
    → Job 1: validate (tag 格式 + tag=pbxproj 版本)
    → Job 2: build (macOS runner, make dmg)
    → Job 3: release (创建 GitHub Release, 上传 DMG)
    → Job 4: update-homebrew (更新 Cask + push homebrew-tap + 更新 submodule)
    → Job 5: summary (发布报告)
```

**版本安全保障**：
- ✅ 允许: `v1.0.10`, `v2.0.0`, `v1.12.3`
- ❌ 拒绝: `v.1.0.10` (tag typo), `v1.0` (不完整), tag ≠ `MARKETING_VERSION`

**所需 Secret**：`HOMEBREW_TAP_TOKEN`（拥有 homebrew-tap 写权限的 [PAT](https://github.com/settings/tokens)，需要 `repo` scope）

### 3. 版本一致性检查 `version-check.yml`

**触发条件**：Push 到 main / PR

| # | 检查项 | 说明 |
|---|--------|------|
| 1 | pbxproj 版本格式 | `MARKETING_VERSION` 必须符合 semver `X.Y.Z` |
| 2 | Cask 版本一致性 | Cask version 与 pbxproj 对比 |
| 3 | Cask Ruby 语法 | `ruby -c Casks/keyden.rb` |
| 4 | 废弃模式检测 | 检查 `depends_on macos: "string"` 等废弃写法 |
| 5 | URL 模板格式 | 检查是否出现 `v.#{version}`（tag typo 检测） |

## 使用指南

```bash
# 发布新版本（CI 自动完成构建、发布、Cask 更新）
git tag v1.0.11 && git push origin v1.0.11

# 首次 clone
git clone --recurse-submodules https://github.com/tasselx/Keyden.git
```

---

CC @tasselx

Co-authored-by: Claude <noreply@anthropic.com>
